### PR TITLE
in scrollEndHandler, hide the spinner if all the children are read

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -378,6 +378,7 @@ Define how your data will come in using these methods:
                 if (item && item.meta) {
                   if (item.meta.total) {
                     if (item.children.length >= item.meta.total) {
+                      _this.spinner('hide');
                       return;
                     }
                     else {


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
When the columnBrowser is scrolled down at the bottom, if all the children are already displayed, the spinner is never hidden.
In scrollEndHandler, if the total is reached (item.children.length >= item.meta.total), the spinner should be hidden before the return statement.

* ## A reference to a related issue (if applicable):
Scrolling issue with lazy loading mode #8

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
